### PR TITLE
add quic transport option

### DIFF
--- a/luasrc/model/cbi/frpc/common.lua
+++ b/luasrc/model/cbi/frpc/common.lua
@@ -120,6 +120,7 @@ o = s:taboption("advanced", ListValue, "protocol", translate("Protocol"),
 o:value("tcp", "TCP")
 o:value("kcp", "KCP")
 o:value("websocket", "Websocket")
+o:value("quic", "quic")
 o.default = "tcp"
 
 o = s:taboption("advanced", Value, "http_proxy", translate("HTTP proxy"),

--- a/root/etc/init.d/frpc
+++ b/root/etc/init.d/frpc
@@ -65,7 +65,7 @@ frpc_scetion_validate() {
 		'pool_count:uinteger:0' \
 		'user:string' \
 		'login_fail_exit:or("true", "false"):true' \
-		'protocol:or("tcp", "kcp", "websocket"):tcp' \
+		'protocol:or("tcp", "kcp", "websocket", "quic"):tcp' \
 		'http_proxy:string' \
 		'tls_enable:or("true", "false")' \
 		'dns_server:host' \


### PR DESCRIPTION
frp upports quic protocol between frpc and frps since 0.46.0: [frp release](https://github.com/fatedier/frp/releases/tag/v0.46.0)